### PR TITLE
[Feature] Add an `https` preset 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Create a `meta.config.js` file at the root of yout project:
 ````ts
 // meta.config.mjs
 import { defineConfig } from '@studiometa/webpack-config';
-import { twig, yaml, tailwindcss, prototyping, eslint, stylelint, withContentHash } from '@studiometa/webpack-config/presets';
+import { twig, yaml, tailwindcss, prototyping, eslint, stylelint, withContentHash, https } from '@studiometa/webpack-config/presets';
 import vue from '@studiometa/webpack-config-preset-vue-3';
 
 export default defineConfig({
@@ -141,6 +141,7 @@ export default defineConfig({
     yaml(), // use the `yaml` preset,
     vue(), // use the Vue 3 preset,
     withContentHash(), // use the content hash preset
+    https(), // use the https preset
     {
       name: 'my-custom-preset',
       handler(metaConfig, { extendWebpack, extendBrowsersync, isDev }) {
@@ -151,15 +152,12 @@ export default defineConfig({
 };
 ````
 
-Configure a `.env` file with the following values:
+Configure a `.env` file with one of the following variable defining your application domain to use for the proxy:
 
 ```bash
 APP_HOST=local.fqdn.com
-APP_SSL=true|false
-
-# If APP_SSL is true, add the following:
-APP_SSL_CERT=/absolute/path/to/ssl/cert
-APP_SSL_KEY=/absolute/path/to/ssl/key
+APP_HOSTNAME=local.fqdn.com
+APP_URL=https://local.fqdn.com
 ```
 
 You can then start the development server:
@@ -203,6 +201,7 @@ Presets can be used to extend the CLI configuration elegantly. The following pre
 - [`yaml`](#yaml)
 - [`vue`](#vue)
 - [`withContentHash`](#withContentHash)
+- [`https`](#https)
 
 Read their documentation below to find out how to use and configure them.
 
@@ -490,6 +489,25 @@ import { withContentHash } from '@studiometa/webpack-config/presets';
 
 export default defineConfig({
   presets: [withContentHash()],
+});
+```
+
+### `https`
+
+Generate an SSL certificate with [`mkcert`](https://github.com/FiloSottile/mkcert) for the local dev server. Can be useful when proxying to an HTTPS only url in dev mode.
+
+#### Options
+
+This preset has no options.
+
+#### Example
+
+```js
+import { defineConfig } from '@studiometa/webpack-config';
+import { https } from '@studiometa/webpack-config/presets';
+
+export default defineConfig({
+  presets: [https()],
 });
 ```
 

--- a/packages/demo/meta.config.js
+++ b/packages/demo/meta.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from '@studiometa/webpack-config';
-import { prototyping, yaml, eslint, stylelint } from '@studiometa/webpack-config/presets';
+import { prototyping, yaml, eslint, stylelint, https } from '@studiometa/webpack-config/presets';
 import vue from '@studiometa/webpack-config-preset-vue-3';
 
 export default defineConfig({
@@ -9,6 +9,7 @@ export default defineConfig({
     prototyping({ ts: true }),
     yaml(),
     vue(),
+    https(),
     {
       name: 'foo',
       handler: (metaConfig, { extendWebpack }) =>

--- a/packages/webpack-config/src/presets/https.js
+++ b/packages/webpack-config/src/presets/https.js
@@ -1,0 +1,71 @@
+import { execSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Create certificates on the fly.
+ * @returns {{cert?:string,key?:string}}
+ */
+function createCertificates() {
+  try {
+    execSync('which mkcert', { encoding: 'utf-8' });
+  } catch {
+    console.log('mkcert not found, skipping creating SSL certificates.');
+    return { cert: null, key: null };
+  }
+  const cachePath = path.join(
+    path.dirname(process.env.npm_package_json),
+    'node_modules/.cache/@studiometa/webpack-config/certificates/'
+  );
+
+  execSync(`mkdir -p ${cachePath}`);
+
+  const certPath = path.join(cachePath, 'localhost.cert');
+  const keyPath = path.join(cachePath, 'localhost.key');
+
+  if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
+    return {
+      cert: certPath,
+      key: keyPath,
+    };
+  }
+
+  try {
+    spawnSync(`mkcert`, [`-cert-file`, certPath, '-key-file', keyPath, 'localhost', '127.0.01']);
+  } catch {
+    console.log('could not create SSL certificates, continuing...');
+    return { cert: null, key: null };
+  }
+
+  return {
+    cert: certPath,
+    key: keyPath,
+  };
+}
+
+/**
+ * ESLint plugin preset.
+ * @returns {import('./index').Preset}
+ */
+export default function https() {
+  return {
+    name: 'https',
+    async handler(config, { extendBrowsersync, isDev }) {
+      if (!isDev) {
+        return;
+      }
+
+      await extendBrowsersync(config, (browserSyncConfig) => {
+        const { cert, key } = createCertificates();
+
+        // Enable `https://` with browserSync
+        if (cert && key) {
+          browserSyncConfig.https = {
+            cert,
+            key,
+          };
+        }
+      });
+    },
+  };
+}

--- a/packages/webpack-config/src/presets/index.d.ts
+++ b/packages/webpack-config/src/presets/index.d.ts
@@ -6,7 +6,7 @@ export type Preset = {
   name: string;
   handler(config: MetaConfig, utils:{
     extendWebpack: typeof extendWebpackConfig,
-    extendBrowserySync: typeof extendBrowsersyncConfig,
+    extendBrowsersync: typeof extendBrowsersyncConfig,
     isDev: boolean,
   }):Promise<void>;
 }

--- a/packages/webpack-config/src/presets/index.js
+++ b/packages/webpack-config/src/presets/index.js
@@ -1,7 +1,8 @@
 export { default as eslint } from './eslint.js';
+export { default as https } from './https.js';
 export { default as prototyping } from './prototyping.js';
 export { default as stylelint } from './stylelint.js';
 export { default as tailwindcss } from './tailwindcss.js';
 export { default as twig } from './twig.js';
-export { default as yaml } from './yaml.js';
 export { default as withContentHash } from './withContentHash.js';
+export { default as yaml } from './yaml.js';

--- a/packages/webpack-config/src/utils/get-browsersync.js
+++ b/packages/webpack-config/src/utils/get-browsersync.js
@@ -1,53 +1,9 @@
-import { execSync, spawnSync } from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
 import bs from 'browser-sync';
 import chalk from 'chalk';
 
 const instance = bs.create();
 
 let WATCH_HANDLERS_BINDED = false;
-
-/**
- * Create certificates on the fly.
- * @returns {{cert?:string,key?:string}}
- */
-function createCertificates() {
-  try {
-    execSync('which mkcert', { encoding: 'utf-8' });
-  } catch {
-    console.log('mkcert not found, skipping creating SSL certificates.');
-    return { cert: null, key: null };
-  }
-  const cachePath = path.join(
-    path.dirname(process.env.npm_package_json),
-    'node_modules/.cache/@studiometa/webpack-config/certificates/'
-  );
-
-  execSync(`mkdir -p ${cachePath}`);
-
-  const certPath = path.join(cachePath, 'localhost.cert');
-  const keyPath = path.join(cachePath, 'localhost.key');
-
-  if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
-    return {
-      cert: certPath,
-      key: keyPath,
-    };
-  }
-
-  try {
-    spawnSync(`mkcert`, [`-cert-file`, certPath, '-key-file', keyPath, 'localhost', '127.0.01']);
-  } catch {
-    console.log('could not create SSL certificates, continuing...');
-    return { cert: null, key: null };
-  }
-
-  return {
-    cert: certPath,
-    key: keyPath,
-  };
-}
 
 const getConfig = (metaConfig) => {
   const browserSyncConfig = {
@@ -101,16 +57,6 @@ const getConfig = (metaConfig) => {
         instance.watch(glob).on('change', instance.reload);
       }
     });
-  }
-
-  const { cert, key } = createCertificates();
-
-  // Enable `https://` with browserSync
-  if (cert && key) {
-    browserSyncConfig.https = {
-      cert,
-      key,
-    };
   }
 
   if (typeof metaConfig.server === 'function') {

--- a/packages/webpack-config/src/utils/get-browsersync.js
+++ b/packages/webpack-config/src/utils/get-browsersync.js
@@ -80,8 +80,8 @@ const getConfig = (metaConfig) => {
   if (metaConfig.server && typeof metaConfig.server !== 'function') {
     browserSyncConfig.server = metaConfig.server;
   } else {
-    const APP_HOST = process.env.APP_HOST || process.env.APP_HOSTNAME;
-    browserSyncConfig.proxy = APP_HOST;
+    browserSyncConfig.proxy =
+      process.env.APP_HOST ?? process.env.APP_HOSTNAME ?? process.env.APP_URL;
   }
 
   if (metaConfig.watch && !WATCH_HANDLERS_BINDED) {


### PR DESCRIPTION
This PR adds an `https` preset to enable `https://` protocol with [`mkcert`](https://github.com/FiloSottile/mkcert) in dev mode.

This requires to have `mkcert` installed locally.

## Changelog
### Added
- Add an `https` preset (#97)

### Removed
- Remove obsolete support of SSL configuration via environment variables (#97)

### Fixed
- Fix types (76a9fa7)
