### PR TITLE
[Feature] Add support for a `context` configuration property

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Create a `meta.config.js` file at the root of yout project:
 ````ts
 // meta.config.mjs
 import { defineConfig } from '@studiometa/webpack-config';
-import { twig, yaml, tailwindcss, prototyping, eslint, stylelint, withContentHash, https } from '@studiometa/webpack-config/presets';
+import { twig, yaml, tailwindcss, prototyping, eslint, stylelint, hash, https } from '@studiometa/webpack-config/presets';
 import vue from '@studiometa/webpack-config-preset-vue-3';
 
 export default defineConfig({
@@ -140,7 +140,7 @@ export default defineConfig({
     prototyping(), // use the `prototyping` preset
     yaml(), // use the `yaml` preset,
     vue(), // use the Vue 3 preset,
-    withContentHash(), // use the content hash preset
+    hash(), // use the content hash preset
     https(), // use the https preset
     {
       name: 'my-custom-preset',
@@ -200,7 +200,7 @@ Presets can be used to extend the CLI configuration elegantly. The following pre
 - [`prototyping`](#prototyping)
 - [`yaml`](#yaml)
 - [`vue`](#vue)
-- [`withContentHash`](#withContentHash)
+- [`hash`](#hash)
 - [`https`](#https)
 
 Read their documentation below to find out how to use and configure them.
@@ -473,7 +473,7 @@ export default defineConfig({
 });
 ```
 
-### `withContentHash`
+### `hash`
 
 Add content hash to filenames in production.
 
@@ -485,10 +485,10 @@ This preset has no options.
 
 ```js
 import { defineConfig } from '@studiometa/webpack-config';
-import { withContentHash } from '@studiometa/webpack-config/presets';
+import { hash } from '@studiometa/webpack-config/presets';
 
 export default defineConfig({
-  presets: [withContentHash()],
+  presets: [hash()],
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@studiometa/eslint-config": "^3.0.5",
+        "@studiometa/eslint-config": "^3.1.0",
         "@studiometa/prettier-config": "^2.1.1",
         "eslint": "^8.25.0",
         "prettier": "^2.7.1"
@@ -2246,14 +2246,17 @@
       }
     },
     "node_modules/@studiometa/eslint-config": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@studiometa/eslint-config/-/eslint-config-3.0.5.tgz",
-      "integrity": "sha512-s4Ai5kqUP7EwMcIVgTQ2rSrxlWB2jTAfI+7C6Qelcm+jVuxu+T5J8h2SqRK0/aziW3WXs6ulPYakK7QJtVrnWg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@studiometa/eslint-config/-/eslint-config-3.1.0.tgz",
+      "integrity": "sha512-6jZFw4VcDNghlPubWefrnGiot9biulpz8aPJ9h+JMHpEtPCvtpeyMvCvC+rnta+JEExdy/Ta0hNDZzZ+W9qkmw==",
       "dev": true,
       "dependencies": {
         "@babel/eslint-parser": "^7.17.0",
         "@rushstack/eslint-patch": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^5.36.0",
+        "@typescript-eslint/parser": "^5.36.0",
         "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-typescript": "^3.3.0",
         "eslint-plugin-import": "^2.25.4",
@@ -2547,6 +2550,12 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -2574,6 +2583,321 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.0.tgz",
+      "integrity": "sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.42.0",
+        "@typescript-eslint/type-utils": "5.42.0",
+        "@typescript-eslint/utils": "5.42.0",
+        "debug": "^4.3.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
+      "integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.42.0",
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/typescript-estree": "5.42.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
+      "integrity": "sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/visitor-keys": "5.42.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.0.tgz",
+      "integrity": "sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.42.0",
+        "@typescript-eslint/utils": "5.42.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.0.tgz",
+      "integrity": "sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz",
+      "integrity": "sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/visitor-keys": "5.42.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.0.tgz",
+      "integrity": "sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.42.0",
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/typescript-estree": "5.42.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz",
+      "integrity": "sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.42.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.2.40",
@@ -5803,6 +6127,21 @@
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-airbnb-typescript": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz",
+      "integrity": "sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==",
+      "dev": true,
+      "dependencies": {
+        "eslint-config-airbnb-base": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.13.0",
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.3"
       }
     },
     "node_modules/eslint-config-prettier": {
@@ -9105,6 +9444,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -13683,6 +14028,27 @@
         "node": ">=0.6.x"
       }
     },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/twig": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/twig/-/twig-1.15.4.tgz",
@@ -14952,7 +15318,7 @@
         "vue": "^3.2.40"
       },
       "devDependencies": {
-        "@studiometa/eslint-config": "^3.0.4",
+        "@studiometa/eslint-config": "^3.1.0",
         "@studiometa/prettier-config": "^2.1.1",
         "@studiometa/stylelint-config": "^2.0.1",
         "@studiometa/webpack-config": "file:../webpack-config",
@@ -15114,7 +15480,7 @@
         "meta": "bin/cli.js"
       },
       "devDependencies": {
-        "@studiometa/eslint-config": "^3.0.5",
+        "@studiometa/eslint-config": "^3.1.0",
         "@studiometa/prettier-config": "^2.1.1",
         "@types/browser-sync": "^2.26.3",
         "eslint": "^8.23.1",
@@ -16630,14 +16996,17 @@
       }
     },
     "@studiometa/eslint-config": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@studiometa/eslint-config/-/eslint-config-3.0.5.tgz",
-      "integrity": "sha512-s4Ai5kqUP7EwMcIVgTQ2rSrxlWB2jTAfI+7C6Qelcm+jVuxu+T5J8h2SqRK0/aziW3WXs6ulPYakK7QJtVrnWg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@studiometa/eslint-config/-/eslint-config-3.1.0.tgz",
+      "integrity": "sha512-6jZFw4VcDNghlPubWefrnGiot9biulpz8aPJ9h+JMHpEtPCvtpeyMvCvC+rnta+JEExdy/Ta0hNDZzZ+W9qkmw==",
       "dev": true,
       "requires": {
         "@babel/eslint-parser": "^7.17.0",
         "@rushstack/eslint-patch": "^1.1.0",
+        "@typescript-eslint/eslint-plugin": "^5.36.0",
+        "@typescript-eslint/parser": "^5.36.0",
         "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-import-resolver-typescript": "^3.3.0",
         "eslint-plugin-import": "^2.25.4",
@@ -16706,7 +17075,7 @@
         "@babel/plugin-transform-runtime": "^7.19.6",
         "@babel/preset-env": "^7.19.4",
         "@soda/friendly-errors-webpack-plugin": "^1.8.1",
-        "@studiometa/eslint-config": "^3.0.5",
+        "@studiometa/eslint-config": "^3.1.0",
         "@studiometa/prettier-config": "^2.1.1",
         "@studiometa/stylelint-config": ">=2.0.0",
         "@types/browser-sync": "^2.26.3",
@@ -16770,7 +17139,7 @@
     "@studiometa/webpack-config-demo": {
       "version": "file:packages/demo",
       "requires": {
-        "@studiometa/eslint-config": "^3.0.4",
+        "@studiometa/eslint-config": "^3.1.0",
         "@studiometa/js-toolkit": "^2.6.0",
         "@studiometa/prettier-config": "^2.1.1",
         "@studiometa/stylelint-config": "^2.0.1",
@@ -17030,6 +17399,12 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -17057,6 +17432,204 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.0.tgz",
+      "integrity": "sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.42.0",
+        "@typescript-eslint/type-utils": "5.42.0",
+        "@typescript-eslint/utils": "5.42.0",
+        "debug": "^4.3.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
+      "integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.42.0",
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/typescript-estree": "5.42.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
+      "integrity": "sha512-l5/3IBHLH0Bv04y+H+zlcLiEMEMjWGaCX6WyHE5Uk2YkSGAMlgdUPsT/ywTSKgu9D1dmmKMYgYZijObfA39Wow==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/visitor-keys": "5.42.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.0.tgz",
+      "integrity": "sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "5.42.0",
+        "@typescript-eslint/utils": "5.42.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.0.tgz",
+      "integrity": "sha512-t4lzO9ZOAUcHY6bXQYRuu+3SSYdD9TS8ooApZft4WARt4/f2Cj/YpvbTe8A4GuhT4bNW72goDMOy7SW71mZwGw==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.0.tgz",
+      "integrity": "sha512-2O3vSq794x3kZGtV7i4SCWZWCwjEtkWfVqX4m5fbUBomOsEOyd6OAD1qU2lbvV5S8tgy/luJnOYluNyYVeOTTg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/visitor-keys": "5.42.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.0.tgz",
+      "integrity": "sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.42.0",
+        "@typescript-eslint/types": "5.42.0",
+        "@typescript-eslint/typescript-estree": "5.42.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.0.tgz",
+      "integrity": "sha512-QHbu5Hf/2lOEOwy+IUw0GoSCuAzByTAWWrOTKzTzsotiUnWFpuKnXcAhC9YztAf2EElQ0VvIK+pHJUPkM0q7jg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.42.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        }
+      }
     },
     "@vue/compiler-core": {
       "version": "3.2.40",
@@ -19460,6 +20033,15 @@
         "semver": "^6.3.0"
       }
     },
+    "eslint-config-airbnb-typescript": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.0.0.tgz",
+      "integrity": "sha512-elNiuzD0kPAPTXjFWg+lE24nMdHMtuxgYoD30OyMD6yrW1AhFZPAg27VX7d3tzOErw+dgJTNWfRSDqEcXb4V0g==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^15.0.0"
+      }
+    },
     "eslint-config-prettier": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
@@ -21759,6 +22341,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.3",
@@ -24965,6 +25553,23 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
     },
     "twig": {
       "version": "1.15.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14634,33 +14634,6 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/webpack-glob-entry": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-glob-entry/-/webpack-glob-entry-2.1.1.tgz",
-      "integrity": "sha512-DwvaAL2F0lsttQiGRg8G0MdGUucvNsU+H8GbcPGS7j4zaz7wWcJFcRqpBuu6BWpumiTeNTLM7PFSwpPdl/CFSA==",
-      "dependencies": {
-        "glob": "^7.1.1"
-      }
-    },
-    "node_modules/webpack-glob-entry/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/webpack-hot-middleware": {
       "version": "2.25.2",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.2.tgz",
@@ -15131,7 +15104,6 @@
         "webpack-assets-manifest": "^5.1.0",
         "webpack-bundle-analyzer": "^4.7.0",
         "webpack-dev-middleware": "^5.3.3",
-        "webpack-glob-entry": "^2.1.1",
         "webpack-hot-middleware": "^2.25.2",
         "webpack-merge": "^5.8.0",
         "webpack-module-hot-accept": "^1.0.5",
@@ -16781,7 +16753,6 @@
         "webpack-assets-manifest": "^5.1.0",
         "webpack-bundle-analyzer": "^4.7.0",
         "webpack-dev-middleware": "^5.3.3",
-        "webpack-glob-entry": "^2.1.1",
         "webpack-hot-middleware": "^2.25.2",
         "webpack-merge": "^5.8.0",
         "webpack-module-hot-accept": "^1.0.5",
@@ -25718,29 +25689,6 @@
         "mime-types": "^2.1.31",
         "range-parser": "^1.2.1",
         "schema-utils": "^4.0.0"
-      }
-    },
-    "webpack-glob-entry": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-glob-entry/-/webpack-glob-entry-2.1.1.tgz",
-      "integrity": "sha512-DwvaAL2F0lsttQiGRg8G0MdGUucvNsU+H8GbcPGS7j4zaz7wWcJFcRqpBuu6BWpumiTeNTLM7PFSwpPdl/CFSA==",
-      "requires": {
-        "glob": "^7.1.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "webpack-hot-middleware": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postversion": "node scripts/update-composer-version.mjs"
   },
   "devDependencies": {
-    "@studiometa/eslint-config": "^3.0.5",
+    "@studiometa/eslint-config": "^3.1.0",
     "@studiometa/prettier-config": "^2.1.1",
     "eslint": "^8.25.0",
     "prettier": "^2.7.1"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -9,7 +9,7 @@
     "build": "node ../webpack-config/bin/cli.js build"
   },
   "devDependencies": {
-    "@studiometa/eslint-config": "^3.0.4",
+    "@studiometa/eslint-config": "^3.1.0",
     "@studiometa/prettier-config": "^2.1.1",
     "@studiometa/stylelint-config": "^2.0.1",
     "@studiometa/webpack-config": "file:../webpack-config",

--- a/packages/demo/src/js/components/Component.ts
+++ b/packages/demo/src/js/components/Component.ts
@@ -1,11 +1,11 @@
 import { Base } from '@studiometa/js-toolkit';
-import type { BaseTypeParameter } from '@studiometa/js-toolkit';
+import type { BaseProps } from '@studiometa/js-toolkit';
 import './Component.scss';
 import type ComponentFoo from '../foo/Component.js';
 
-interface ComponentInterface extends BaseTypeParameter {
+interface ComponentInterface extends BaseProps {
   $children: {
-    ComponentFoo: Promise<ComponentFoo>;
+    ComponentFoo: Promise<ComponentFoo>[];
   };
   $refs: {
     btn: HTMLButtonElement;
@@ -13,7 +13,7 @@ interface ComponentInterface extends BaseTypeParameter {
 }
 
 export default class Component<
-  T extends BaseTypeParameter = BaseTypeParameter
+  T extends BaseProps = BaseProps
 > extends Base<ComponentInterface> {
   static config = {
     name: 'Component',
@@ -23,7 +23,7 @@ export default class Component<
   };
 
   async mounted() {
-    // const foo = await this.$children.ComponentFoo[0];
-    // console.log(foo.$options.foo, foo.$refs.btn);
+    const foo = await this.$children.ComponentFoo[0];
+    console.log(foo.$options.foo, foo.$refs.btn);
   }
 }

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -105,7 +105,6 @@
     "webpack-assets-manifest": "^5.1.0",
     "webpack-bundle-analyzer": "^4.7.0",
     "webpack-dev-middleware": "^5.3.3",
-    "webpack-glob-entry": "^2.1.1",
     "webpack-hot-middleware": "^2.25.2",
     "webpack-merge": "^5.8.0",
     "webpack-module-hot-accept": "^1.0.5",

--- a/packages/webpack-config/package.json
+++ b/packages/webpack-config/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/studiometa/webpack-config#readme",
   "devDependencies": {
-    "@studiometa/eslint-config": "^3.0.5",
+    "@studiometa/eslint-config": "^3.1.0",
     "@studiometa/prettier-config": "^2.1.1",
     "@types/browser-sync": "^2.26.3",
     "eslint": "^8.23.1",

--- a/packages/webpack-config/src/index.d.ts
+++ b/packages/webpack-config/src/index.d.ts
@@ -33,6 +33,10 @@ export interface MetaConfig {
    */
   public?: string;
   /**
+   * Base path for path resolution.
+   */
+  context?: string;
+  /**
    * Analyze the bundle with the WebpackBundleAnalyzer plugin.
    */
   analyze?: boolean;

--- a/packages/webpack-config/src/index.d.ts
+++ b/packages/webpack-config/src/index.d.ts
@@ -15,11 +15,7 @@ export interface MetaConfig {
   /**
    * Toggle the modern build.
    */
-  modern?: boolean;
-  /**
-   * Toggle the legacy build.
-   */
-  legacy?: boolean;
+  target?: 'modern'|'legacy'|Array<'modern'|'legacy'>;
   /**
    * A list of glob for files to consider as entries.
    */

--- a/packages/webpack-config/src/index.js
+++ b/packages/webpack-config/src/index.js
@@ -5,8 +5,10 @@ import getWebpackDevConfig from './webpack.dev.config.js';
 /**
  * Create a configuration.
  *
- * @param  {MetaConfig} config
- * @returns {MetaConfig}
+ * @deprecated Use `defineConfig` instead.
+ * @template  {import('./index').MetaConfig} T
+ * @param  {T} config
+ * @returns {T}
  */
 export function createConfig(config) {
   return config;
@@ -14,7 +16,8 @@ export function createConfig(config) {
 
 /**
  * Define the configuration.
- * @template {MetaConfig} T
+ *
+ * @template {import('./index').MetaConfig} T
  * @param   {T} config
  * @returns {T}
  */

--- a/packages/webpack-config/src/presets/hash.js
+++ b/packages/webpack-config/src/presets/hash.js
@@ -2,9 +2,9 @@
  * With hash preset.
  * @returns {import('./index').Preset}
  */
-export default function withContentHash() {
+export default function hash() {
   return {
-    name: 'with-content-hash',
+    name: 'hash',
     async handler(config, { extendWebpack, isDev }) {
       if (isDev) {
         return;

--- a/packages/webpack-config/src/presets/index.js
+++ b/packages/webpack-config/src/presets/index.js
@@ -4,5 +4,7 @@ export { default as prototyping } from './prototyping.js';
 export { default as stylelint } from './stylelint.js';
 export { default as tailwindcss } from './tailwindcss.js';
 export { default as twig } from './twig.js';
-export { default as withContentHash } from './withContentHash.js';
+// @todo remove v5
+export { default as withContentHash } from './hash.js';
+export { default as hash } from './hash.js';
 export { default as yaml } from './yaml.js';

--- a/packages/webpack-config/src/presets/prototyping.js
+++ b/packages/webpack-config/src/presets/prototyping.js
@@ -159,9 +159,10 @@ export default function prototyping(options) {
       const { handler: tailwindcssPresetHandler } = tailwindcssPreset(opts.tailwindcss);
       await tailwindcssPresetHandler(config, { extendWebpack, extendBrowsersync, isDev });
 
+      config.context = './src';
       config.src = [
-        opts.ts ? './src/js/app.ts' : './src/js/app.js',
-        './src/css/**/[!_]*.scss',
+        opts.ts ? './js/app.ts' : './js/app.js',
+        './css/**/[!_]*.scss',
         ...(config.src ?? []),
       ];
       config.dist = config.dist ?? './dist';

--- a/packages/webpack-config/src/presets/prototyping.js
+++ b/packages/webpack-config/src/presets/prototyping.js
@@ -159,10 +159,9 @@ export default function prototyping(options) {
       const { handler: tailwindcssPresetHandler } = tailwindcssPreset(opts.tailwindcss);
       await tailwindcssPresetHandler(config, { extendWebpack, extendBrowsersync, isDev });
 
-      config.context = './src';
       config.src = [
-        opts.ts ? './js/app.ts' : './js/app.js',
-        './css/**/[!_]*.scss',
+        opts.ts ? './src/js/app.ts' : './src/js/app.js',
+        './src/css/**/[!_]*.scss',
         ...(config.src ?? []),
       ];
       config.dist = config.dist ?? './dist';

--- a/packages/webpack-config/src/utils/get-browsersync.js
+++ b/packages/webpack-config/src/utils/get-browsersync.js
@@ -56,11 +56,11 @@ async function getConfig(metaConfig) {
             'A watch item should implement the following schema: [glob:string, callback:function]'
           );
         }
-        instance.watch(fileGlob, (event, file) => {
+        instance.watch(fileGlob, { cwd: metaConfig.context }, (event, file) => {
           callback(event, file, instance, browserSyncConfig);
         });
       } else {
-        instance.watch(glob).on('change', instance.reload);
+        instance.watch(glob, { cwd: metaConfig.context }).on('change', instance.reload);
       }
     });
   }

--- a/packages/webpack-config/src/utils/get-config.js
+++ b/packages/webpack-config/src/utils/get-config.js
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { findUp } from 'find-up';
 import extendBrowsersync from './extend-browsersync-config.js';
 import extendWebpack from './extend-webpack-config.js';
@@ -47,6 +48,14 @@ export default async function getConfig({ analyze = false, target = [] } = {}) {
         isDev: process.env.NODE_ENV !== 'production',
       });
     }
+  }
+
+  if (!config.context) {
+    config.context = path.dirname(configPath);
+  }
+
+  if (!path.isAbsolute(config.context)) {
+    config.context = path.resolve(process.cwd(), config.context);
   }
 
   // Read from command line args first, then meta.config.js, then set default

--- a/packages/webpack-config/src/utils/get-config.js
+++ b/packages/webpack-config/src/utils/get-config.js
@@ -31,21 +31,22 @@ export default async function getConfig({ analyze = false, target = [] } = {}) {
   if (Array.isArray(config.presets) && config.presets.length) {
     console.log('Applying presets...');
 
-    await Promise.all(
-      config.presets.map(async (preset) => {
-        if (!preset.name && typeof preset.handler !== 'function') {
-          console.log('Preset misconfigured.', preset);
-          return;
-        }
+    // eslint-disable-next-line no-restricted-syntax
+    for (const preset of config.presets) {
+      if (!preset.name && typeof preset.handler !== 'function') {
+        console.log('Preset misconfigured.', preset);
+        return;
+      }
 
-        console.log(`Using the "${preset.name}" preset.`);
-        await preset.handler(config, {
-          extendBrowsersync,
-          extendWebpack,
-          isDev: process.env.NODE_ENV !== 'production',
-        });
-      })
-    );
+      console.log(`Using the "${preset.name}" preset.`);
+
+      // eslint-disable-next-line no-await-in-loop
+      await preset.handler(config, {
+        extendBrowsersync,
+        extendWebpack,
+        isDev: process.env.NODE_ENV !== 'production',
+      });
+    }
   }
 
   // Read from command line args first, then meta.config.js, then set default

--- a/packages/webpack-config/src/webpack.base.config.js
+++ b/packages/webpack-config/src/webpack.base.config.js
@@ -1,6 +1,6 @@
-import path from 'path';
+import path from 'node:path';
 import WebpackBar from 'webpackbar';
-import entry from 'webpack-glob-entry';
+import glob from 'glob';
 import RemoveEmptyScriptsPlugin from 'webpack-remove-empty-scripts';
 import webpack from 'webpack';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
@@ -55,11 +55,17 @@ export default async function getWebpackBaseConfig(config, options = {}) {
     },
   };
 
+  const entry = Object.fromEntries(
+    config.src.flatMap((entryGlob) => {
+      return glob.sync(entryGlob, { cwd: config.context }).map((file) => {
+        return [file.replace(src, '').replace(path.extname(file), ''), file];
+      });
+    })
+  );
+
   const webpackBaseConfig = {
-    entry: entry((filePath) => {
-      const extname = path.extname(filePath);
-      return filePath.replace(src, '').replace(extname, '');
-    }, ...config.src),
+    context: config.context,
+    entry,
     devtool: 'source-map',
     target: ['web', isModern ? 'es6' : 'es5'],
     output: {

--- a/packages/webpack-config/src/webpack.base.config.js
+++ b/packages/webpack-config/src/webpack.base.config.js
@@ -70,7 +70,7 @@ export default async function getWebpackBaseConfig(config, options = {}) {
     target: ['web', isModern ? 'es6' : 'es5'],
     output: {
       path: path.resolve(
-        path.dirname(config.PATH),
+        config.context,
         config.dist,
         config.modern && config.legacy && isLegacy ? '__legacy__' : ''
       ),


### PR DESCRIPTION
This can be used to define the context in which the `config.src`, `config.dist` and `config.watch` paths will be resolved. Its value will default to the `meta.config.js` file directory.

## Changelog
### Added
- Add support for a `context` configuration property ()

### Changed
- Improve types (a7b6340)
- Rename the `withContentHash` preset to `hash` (dfe8230)

### Fixed
- Fix order of execution of each presets (ada35db)
