### PR TITLE
[Bugfix] Fix CJS files being incorrectly transformed to ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix CJS files being incorrectly transformed to ESM ([#172](https://github.com/studiometa/webpack-config/pull/172), [e4cccc2](https://github.com/studiometa/webpack-config/commit/e4cccc2))
+
 ## [v6.2.0](https://github.com/studiometa/webpack-config/compare/6.1.0..6.2.0) (2024-10-03)
 
 ### Added

--- a/packages/webpack-config/src/webpack.base.config.js
+++ b/packages/webpack-config/src/webpack.base.config.js
@@ -87,15 +87,12 @@ export default async function getWebpackBaseConfig(config, { mode = 'production'
         },
         {
           test: /\.m?(j|t)s$/,
-          // Exclude all but packages from the `@studiometa/` namespace
-          exclude: [/node_modules[\\/](?!@studiometa[\\/]).*/],
           type: 'javascript/auto',
           use: {
             loader: 'esbuild-loader',
             options: {
               loader: 'ts',
               target: isDev ? 'es2022' : 'es2020',
-              format: 'esm',
             },
           },
         },


### PR DESCRIPTION
This PR fixes a recurring bug where some packages were being transpiled from CJS to ESM, resulting in exports sometimes being incorrectly transformed (i.e. js-cookie, mapbox-gl).