### PR TITLE
[Bugfix] Fix a bug where inline images were considered as resolvable

### DIFF
--- a/packages/preset-prototyping/src/presets/twig.js
+++ b/packages/preset-prototyping/src/presets/twig.js
@@ -33,6 +33,7 @@ export default function twig(options = {}) {
                   urlFilter(attribute, value) {
                     if (
                       value.startsWith('/') ||
+                      value.startsWith('data:') ||
                       value.startsWith('//') ||
                       value.startsWith('http://') ||
                       value.startsWith('https://')


### PR DESCRIPTION
Inline `data:...` images should not be considered to be imported.